### PR TITLE
Fix Sass mixin warnings

### DIFF
--- a/ui/scss/_mixins.scss
+++ b/ui/scss/_mixins.scss
@@ -1,12 +1,16 @@
+@use "sass:math";
+@use "sass:list";
+@use "sass:meta";
+
 @function box-shadow($stars) {
-	$bxshadow: ();
-	@for $i from 1 to $stars {
-		$bxshadow: append($bxshadow, (random(2000) + 0px) (random(2000) + 0px) #fff, comma);
-	}
+  $bxshadow: ();
+  @for $i from 1 to $stars {
+    $bxshadow: list.append($bxshadow, (math.random(2000) + 0px) (math.random(2000) + 0px) #fff, comma);
+  }
 
-	@if type-of($bxshadow) == string {
-		$bxshadow: unquote($bxshadow);
-	}
+  @if meta.type-of($bxshadow) == "string" {
+    $bxshadow: unquote($bxshadow);
+  }
 
-	@return $bxshadow;
+  @return $bxshadow;
 }


### PR DESCRIPTION
## Summary
- update SCSS mixins to use `sass:math`, `sass:list`, and `sass:meta`

## Testing
- `npm run build-ui`

------
https://chatgpt.com/codex/tasks/task_e_6845be03ebfc832fbc355a63c07ccebc