### PR TITLE
Fix width for weather scene

### DIFF
--- a/ui/css/app.css
+++ b/ui/css/app.css
@@ -80,7 +80,7 @@ body {
 }
 
 #app {
-  width: 280px;
+  width: 400px;
   height: 480px;
   margin: 0 auto;
   box-shadow: 10px 10px 10px rgba(0, 0, 0, 0.5);

--- a/ui/scene.css
+++ b/ui/scene.css
@@ -13,7 +13,7 @@ body {
 
 #scene {
   position: relative;
-  width: 280px;
+  width: 400px;
   height: 480px;
   margin: 0 auto;
   box-shadow: 10px 10px 10px rgba(0, 0, 0, 0.5);

--- a/ui/scss/weather/_fog.scss
+++ b/ui/scss/weather/_fog.scss
@@ -3,7 +3,7 @@
   position: absolute;
   bottom: 0;
   left: 0;
-  width: 280px;
+  width: 400px;
   height: 175px;
   background-size: cover;
   z-index: 25;

--- a/ui/scss/weather/_rain.scss
+++ b/ui/scss/weather/_rain.scss
@@ -4,13 +4,13 @@
   left: 0;
   z-index: 15;
   height: 480px;
-  width: 280px;
+  width: 400px;
 
   .rain {
     position: absolute;
     left: 0;
     top: 0;
-    width: 280px;
+    width: 400px;
     height: 480px;
     z-index: 15;
     transform: translate3d(0, 0, 0);


### PR DESCRIPTION
## Summary
- expand weather scene width to 400px so background covers the entire view
- adjust rain and fog overlays to match the new width

## Testing
- `npm run build-ui`

------
https://chatgpt.com/codex/tasks/task_e_6845d90ee914832f86fa5b193b2b59de