### PR TITLE
Fix positional argument parsing in weather preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ This example demonstrates how to fetch weather data from OpenWeatherMap and pars
    ```bash
    npm run weather-ui -- --lat 40.7128 --lon -74.0060
    ```
+   You can also pass the latitude and longitude positionally (note the space after `--`):
+   ```bash
+   npm run weather-ui -- 40.7128 -74.0060
+   ```
    This fetches live data and opens an Electron window showing the animated scene.
 5. Run the parser with latitude and longitude:
    ```bash

--- a/src/weather_ui.js
+++ b/src/weather_ui.js
@@ -11,10 +11,27 @@ import fs from 'fs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-const argv = yargs(hideBin(process.argv)).options({
-  lat: { type: 'number', demandOption: true },
-  lon: { type: 'number', demandOption: true }
-}).argv;
+const argvRaw = yargs(hideBin(process.argv))
+  .options({
+    lat: { type: 'number' },
+    lon: { type: 'number' }
+  })
+  .parseSync();
+
+let { lat, lon, _ } = argvRaw;
+const positionalNumbers = _
+  .map(val => parseFloat(val))
+  .filter(n => !isNaN(n));
+
+if ((lat === undefined || isNaN(lat)) && positionalNumbers.length >= 2) {
+  lat = positionalNumbers[positionalNumbers.length - 2];
+  lon = positionalNumbers[positionalNumbers.length - 1];
+}
+
+if (isNaN(lat) || isNaN(lon)) {
+  console.error('Latitude and longitude are required. Pass with --lat and --lon or as positional arguments.');
+  process.exit(1);
+}
 
 const API_KEY = process.env.OPENWEATHER_API_KEY;
 if (!API_KEY) {
@@ -106,7 +123,7 @@ function createWindow(weather) {
 app.whenReady()
   .then(async () => {
     console.log('[weather_ui] app ready');
-    const raw = await fetchWeather(argv.lat, argv.lon);
+    const raw = await fetchWeather(lat, lon);
     const parsed = util.parseWeather('location', raw, settings);
     console.log('[weather_ui] weather parsed, creating window');
     createWindow(parsed);


### PR DESCRIPTION
## Summary
- handle Electron argument quirk by using the last numeric positional values as coordinates
- clarify the README example to emphasise spacing after `--`

## Testing
- `npm install`
- `npm run build-ui`
- `node src/index.js --lat 0 --lon 0`


------
https://chatgpt.com/codex/tasks/task_e_6845fc1855a0832f826621d308b08695