### PR TITLE
Handle swiper build error in Vite

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,7 @@ This launches an Electron process that fetches the weather, builds the menubar p
 - **Sass reports `Can't find stylesheet to import`:** Use the `@use` syntax
   for SCSS modules (e.g. `@use '@/scss/mixins' as *;`) and ensure the `@`
   alias is configured in `vite.config.js`.
+- **Build fails with `[commonjs--resolver] Missing "./modules" specifier in
+  "swiper" package`:** Install dependencies again with `npm install` and ensure
+  the project uses Swiper v11 or later. If the error persists, delete your
+  `node_modules` folder and reinstall.

--- a/vite.config.js
+++ b/vite.config.js
@@ -19,6 +19,9 @@ export default defineConfig({
       }
     }
   },
+  optimizeDeps: {
+    include: ['swiper/modules']
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, 'ui')


### PR DESCRIPTION
## Summary
- ensure Vite prebundles Swiper modules
- add troubleshooting note for the Swiper modules error

## Testing
- `npm run build-ui`

------
https://chatgpt.com/codex/tasks/task_e_68460fcfa408832f87655e050b02df27