### PR TITLE
Add demo flag for weather animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,19 @@ This example demonstrates how to fetch weather data from OpenWeatherMap and pars
    ```
    This populates the `ui/dist` folder required by the Electron weather preview.
 4. Launch the graphical preview with your coordinates:
-   ```bash
-   npm run weather-ui -- --lat 40.7128 --lon -74.0060
-   ```
+  ```bash
+  npm run weather-ui -- --lat 40.7128 --lon -74.0060
+  ```
    You can also pass the latitude and longitude positionally. **Make sure there is a space after `--`** or npm will treat the numbers as option names:
-   ```bash
-   npm run weather-ui -- 40.7128 -74.0060
-   ```
-   (Incorrect: `npm run weather-ui --40.7128 --74.0060`)
-   This fetches live data and opens an Electron window showing the animated scene.
+  ```bash
+  npm run weather-ui -- 40.7128 -74.0060
+  ```
+  (Incorrect: `npm run weather-ui --40.7128 --74.0060`)
+  This fetches live data and opens an Electron window showing the animated scene.
+  To force all animations on for testing, add the `--demo` flag:
+  ```bash
+  npm run weather-ui -- --lat 40.7128 --lon -74.0060 --demo
+  ```
 5. Run the parser with latitude and longitude:
    ```bash
    node src/index.js --lat 40.7128 --lon -74.0060

--- a/src/weather_ui.js
+++ b/src/weather_ui.js
@@ -17,7 +17,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const argvRaw = yargs(hideBin(process.argv))
   .options({
     lat: { type: 'number' },
-    lon: { type: 'number' }
+    lon: { type: 'number' },
+    demo: { type: 'boolean', default: false,
+      describe: 'Show all weather animations regardless of real data' }
   })
   .parseSync();
 
@@ -128,6 +130,21 @@ app.whenReady()
     console.log('[weather_ui] app ready');
     const raw = await fetchWeather(lat, lon);
     const parsed = util.parseWeather('location', raw, settings);
+    if (argvRaw.demo) {
+      console.log('[weather_ui] demo mode - enabling all animations');
+      Object.assign(parsed, {
+        scene_clouds: true,
+        scene_cloud_percent: 100,
+        scene_fog: true,
+        scene_lightning: true,
+        scene_moon: true,
+        scene_rain: 100,
+        scene_snow: true,
+        scene_stars: true,
+        scene_sun: true,
+        scene_thunderstorm: true
+      });
+    }
     console.log('[weather_ui] weather parsed, creating window');
     createWindow(parsed);
   })

--- a/ui/weather.html
+++ b/ui/weather.html
@@ -8,6 +8,8 @@
   <link rel="stylesheet" href="css/fontawesome-all.css">
   <link rel="stylesheet" href="css/weather-icons.css">
   <link rel="stylesheet" href="css/app.css">
+  <!-- Include the full animation rules without overriding base layout -->
+  <link rel="stylesheet" href="css/style.css">
   <link rel="stylesheet" href="scene.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- add a `--demo` option to `weather_ui.js` so all animations can be forced on
- document demo flag usage in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684613fe3094832f9a92a04a0b27c492