### PR TITLE
Add demo page for previewing animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,19 @@ This example demonstrates how to fetch weather data from OpenWeatherMap and pars
    ```
    This populates the `ui/dist` folder required by the Electron weather preview.
 4. Launch the graphical preview with your coordinates:
-   ```bash
-   npm run weather-ui -- --lat 40.7128 --lon -74.0060
-   ```
+  ```bash
+  npm run weather-ui -- --lat 40.7128 --lon -74.0060
+  ```
    You can also pass the latitude and longitude positionally. **Make sure there is a space after `--`** or npm will treat the numbers as option names:
-   ```bash
-   npm run weather-ui -- 40.7128 -74.0060
-   ```
-   (Incorrect: `npm run weather-ui --40.7128 --74.0060`)
-   This fetches live data and opens an Electron window showing the animated scene.
+  ```bash
+  npm run weather-ui -- 40.7128 -74.0060
+  ```
+  (Incorrect: `npm run weather-ui --40.7128 --74.0060`)
+  This fetches live data and opens an Electron window showing the animated scene.
+  To force all animations on for testing, add the `--demo` flag:
+  ```bash
+ npm run weather-ui -- --lat 40.7128 --lon -74.0060 --demo
+  ```
 5. Run the parser with latitude and longitude:
    ```bash
    node src/index.js --lat 40.7128 --lon -74.0060
@@ -39,6 +43,9 @@ This example demonstrates how to fetch weather data from OpenWeatherMap and pars
    ```cmd
    node src\index.js --lat 40.7128 --lon -74.0060
    ```
+6. To preview the animated scene in a regular browser, open `ui/demo.html`
+   after building the UI assets. This page loads sample weather data so all
+   effects are visible without Electron.
 
 The script prints the parsed JSON to stdout.
 

--- a/src/weather_ui.js
+++ b/src/weather_ui.js
@@ -17,7 +17,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const argvRaw = yargs(hideBin(process.argv))
   .options({
     lat: { type: 'number' },
-    lon: { type: 'number' }
+    lon: { type: 'number' },
+    demo: { type: 'boolean', default: false,
+      describe: 'Show all weather animations regardless of real data' }
   })
   .parseSync();
 
@@ -128,6 +130,21 @@ app.whenReady()
     console.log('[weather_ui] app ready');
     const raw = await fetchWeather(lat, lon);
     const parsed = util.parseWeather('location', raw, settings);
+    if (argvRaw.demo) {
+      console.log('[weather_ui] demo mode - enabling all animations');
+      Object.assign(parsed, {
+        scene_clouds: true,
+        scene_cloud_percent: 100,
+        scene_fog: true,
+        scene_lightning: true,
+        scene_moon: true,
+        scene_rain: 100,
+        scene_snow: true,
+        scene_stars: true,
+        scene_sun: true,
+        scene_thunderstorm: true
+      });
+    }
     console.log('[weather_ui] weather parsed, creating window');
     createWindow(parsed);
   })

--- a/ui/demo.html
+++ b/ui/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Weather Demo</title>
+  <link rel="stylesheet" href="css/animate.css">
+  <link rel="stylesheet" href="css/fontawesome-all.css">
+  <link rel="stylesheet" href="css/weather-icons.css">
+  <link rel="stylesheet" href="css/app.css">
+  <link rel="stylesheet" href="css/style.css">
+  <link rel="stylesheet" href="scene.css">
+</head>
+<body>
+  <div id="app"></div>
+  <link rel="stylesheet" href="dist/assets/main.css" />
+  <script>
+    window.demoWeather = {
+      scene_clouds: true,
+      scene_cloud_percent: 100,
+      scene_fog: true,
+      scene_lightning: true,
+      scene_moon: true,
+      scene_rain: 100,
+      scene_snow: true,
+      scene_stars: true,
+      scene_sun: true,
+      scene_thunderstorm: true,
+      scene_time: 'noon',
+      scene_wind_speed: 15,
+      scene_wind_direction: 0,
+      condition_icon: 'wi-day-sunny',
+      condition_label: 'Demo',
+      temp_actual: 72
+    };
+  </script>
+  <script type="module" src="dist/main.js"></script>
+</body>
+</html>

--- a/ui/main.js
+++ b/ui/main.js
@@ -2,6 +2,7 @@ import { createApp, h } from 'vue'
 import WeatherApp from './WeatherApp.vue'
 
 const ipc = window.require ? window.require('electron').ipcRenderer : null
+const demoWeather = window.demoWeather || null
 
 createApp({
   data() {
@@ -21,6 +22,9 @@ createApp({
           console.error('weather data not received')
         }
       }, 5000)
+    } else if (demoWeather) {
+      // Allow a static demo when not running in Electron
+      this.weather = demoWeather
     }
   }
 }).mount('#app')

--- a/ui/weather.html
+++ b/ui/weather.html
@@ -8,6 +8,8 @@
   <link rel="stylesheet" href="css/fontawesome-all.css">
   <link rel="stylesheet" href="css/weather-icons.css">
   <link rel="stylesheet" href="css/app.css">
+  <!-- Include the full animation rules without overriding base layout -->
+  <link rel="stylesheet" href="css/style.css">
   <link rel="stylesheet" href="scene.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- provide a browser-friendly demo page
- allow `ui/main.js` to load demo data when not in Electron
- document browser demo usage in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684613fe3094832f9a92a04a0b27c492